### PR TITLE
fix(terraform): save plan file for apply step on main branch

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -66,7 +66,12 @@ jobs:
 
     - name: Terraform Plan
       id: plan
-      run: terraform plan -var-file="environments/${{ github.event.inputs.environment || 'dev' }}.tfvars" -no-color
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          terraform plan -var-file="environments/${{ github.event.inputs.environment || 'dev' }}.tfvars" -no-color
+        else
+          terraform plan -var-file="environments/${{ github.event.inputs.environment || 'dev' }}.tfvars" -out=tfplan
+        fi
       continue-on-error: true
       
     - name: Comment PR with Plan


### PR DESCRIPTION
## Problem

Infrastructure Deployment workflow fails on main branch with error:
`
Error: Failed to load 'tfplan' as a plan file
Error: stat tfplan: no such file or directory
`

**Failed workflow**: https://github.com/MatGhp/CV-Analyzer/actions/runs/19478582747

## Root Cause

- Terraform Plan step runs on both pull_request and push events
- Plan command doesn't save output file: 	erraform plan ... -no-color
- Terraform Apply step expects plan file: 	erraform apply -auto-approve tfplan
- On push to main, plan file is never created  apply fails

## Solution

Add conditional logic to Plan step:
- **PR event**: Run plan without output file (for PR comment)
- **Push event**: Run plan WITH output file (-out=tfplan) for apply step

## Changes

- Modified .github/workflows/infra-deploy.yml
- Added bash conditional to check github.event_name
- PR workflow unchanged (still comments plan)
- Main branch workflow now saves plan file for apply

## Testing

 CI Build and Test will validate workflow syntax
 Infrastructure Deployment will run Terraform plan (no apply on PR)
 After merge, main deployment will use saved plan file

## Benefits

-  Fixes infrastructure deployment on main branch
-  Preserves PR comment functionality
-  Follows Terraform best practice (plan  apply same file)
-  Prevents drift between plan review and apply execution