### PR TITLE
fix(ci): resolve health check false negatives

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -118,8 +118,18 @@ jobs:
             
             # Health endpoint checks with 3 retries
             for j in 1 2 3; do
-              API_HEALTH=$(curl -sf "https://$API_URL/api/health" && echo "OK" || echo "FAIL")
-              FRONTEND_HEALTH=$(curl -sf "https://$FRONTEND_URL/health" && echo "OK" || echo "FAIL")
+              # Use curl exit code only (discard response body)
+              if curl -sf "https://$API_URL/api/health" > /dev/null; then
+                API_HEALTH="OK"
+              else
+                API_HEALTH="FAIL"
+              fi
+              
+              if curl -sf "https://$FRONTEND_URL/health" > /dev/null; then
+                FRONTEND_HEALTH="OK"
+              else
+                FRONTEND_HEALTH="FAIL"
+              fi
               
               if [ "$API_HEALTH" == "OK" ] && [ "$FRONTEND_HEALTH" == "OK" ]; then
                 echo "[PASS] All health checks passed"


### PR DESCRIPTION
Fixes deployment workflow health check logic that was incorrectly failing despite services being healthy.

**Problem:** curl captured response body + "OK", causing string comparison to fail
**Solution:** Check curl exit code only, discard response body

**Changes:**
- Fixed health check bash logic in app-deploy.yml
- Updated copilot-instructions.md with correct pattern and common pitfalls