### PR TITLE
fix(terraform): enable custom subdomain for Document Intelligence

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -48,6 +48,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = "~> 0.12.1"
   hashes = [
     "h1:6BhxSYBJdBBKyuqatOGkuPKVenfx6UmLdiI13Pb3his=",
+    "h1:VgFDnbNB6f13IXMkO9dRNNkcJFk0/SOM0e82qhO1e8I=",
     "zh:090023137df8effe8804e81c65f636dadf8f9d35b79c3afff282d39367ba44b2",
     "zh:26f1e458358ba55f6558613f1427dcfa6ae2be5119b722d0b3adb27cd001efea",
     "zh:272ccc73a03384b72b964918c7afeb22c2e6be22460d92b150aaf28f29a7d511",

--- a/terraform/environments/prod.tfvars
+++ b/terraform/environments/prod.tfvars
@@ -13,9 +13,9 @@ sql_database_sku   = "S1"           # S1 SKU for production (better performance)
 acr_sku = "Standard" # Standard SKU for better performance and geo-replication in prod
 
 # Container Apps Configuration
-min_replicas = 1  # Always-on for production
-max_replicas = 10 # Higher capacity for production load
-enable_health_probes = true  # REQUIRED for production per Azure best practices
+min_replicas         = 1    # Always-on for production
+max_replicas         = 10   # Higher capacity for production load
+enable_health_probes = true # REQUIRED for production per Azure best practices
 
 # AI Configuration
 model_deployment_name = "gpt-4o"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ locals {
     Environment = var.environment
     Application = "cvanalyzer"
   }
-  
+
   # Health probes: Bootstrap Exception to Azure Best Practices
   # - Production: ALWAYS enabled (true) per Azure guidelines
   # - Dev/Test: Disabled (false) ONLY during initial Terraform deployment with placeholder images

--- a/terraform/modules/document-intelligence/main.tf
+++ b/terraform/modules/document-intelligence/main.tf
@@ -2,11 +2,26 @@
 # Provides FormRecognizer service for PDF/DOCX text extraction
 
 resource "azurerm_cognitive_account" "main" {
-  name                = "${var.name_prefix}-docintel"
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  kind                = "FormRecognizer"
-  sku_name            = var.sku_name
+  name                          = "${var.name_prefix}-docintel"
+  location                      = var.location
+  resource_group_name           = var.resource_group_name
+  kind                          = "FormRecognizer"
+  sku_name                      = var.sku_name
+  custom_subdomain_name         = "${var.name_prefix}-docintel"
+  public_network_access_enabled = true
+
+  # Network ACLs: Allow Container Apps and Azure services
+  # Note: Container Apps Consumption plan uses dynamic outbound IPs
+  # For production, consider Private Endpoints with VNet integration
+  network_acls {
+    default_action = "Allow" # "Deny" requires static IPs or Private Endpoint
+    
+    # Bypass Azure services for managed identity token exchange
+    bypass = ["AzureServices"]
+    
+    # IP rules can be added when Container Apps uses static outbound IPs
+    # ip_rules = var.allowed_ip_ranges
+  }
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
Fixes resume analysis authentication error. Document Intelligence now uses custom subdomain endpoint required for managed identity token auth. Endpoint changes from regional to resource-specific URL. Requires terraform apply after merge.